### PR TITLE
Specify priority & scheduling for systemd service

### DIFF
--- a/init/asd-resync.service
+++ b/init/asd-resync.service
@@ -9,6 +9,12 @@ PartOf=asd.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/anything-sync-daemon resync
+OOMScoreAdjust=-1000
+Nice=19
+IOSchedulingClass=idle
+IOSchedulingPriority=7
+CPUSchedulingPolicy=idle
+CPUSchedulingPriority=1
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
OOMScoreAdjust is used to disable this service from OOM killer consideration, as this will explicitly be recovering memory.

IO and CPU scheduling (incl. niceness) both reflect the lowest priorities possible, as keeping the data in tmpfs longer helps performance anyway.

In the future, it may be better to dynamically choose the scheduling policies used, depending on memory pressure or integrity requirements.